### PR TITLE
Correctly account for elements at bottom of page

### DIFF
--- a/lib/cropImage.js
+++ b/lib/cropImage.js
@@ -40,7 +40,7 @@ module.exports = function(res, done) {
          * @see https://github.com/webdriverio/webdrivercss/issues/5
          */
         if(this.instance.desiredCapabilities.browserName === 'firefox') {
-            res.value.elemBounding.top = res.value.scrollPos.y;
+            res.value.elemBounding.top = res.value.scrollPos.y+res.value.elemBounding.top;
         }
 
         cropDim = {


### PR DESCRIPTION
Previous fix for issue #5 didn't take into account elements in firefox which are below possible scroll position
