### PR TITLE
Make renaming files optional

### DIFF
--- a/lib/renameFiles.js
+++ b/lib/renameFiles.js
@@ -19,7 +19,7 @@ module.exports = function() {
         /**
          * rename existing files
          */
-        if(files.length === 2) {
+        if(files.length === 2 && this.self.updateBaseImages) {
             return fs.rename(this.regressionPath, this.baselinePath, done);
         } else {
             return done();

--- a/lib/webdrivercss.js
+++ b/lib/webdrivercss.js
@@ -52,16 +52,8 @@ var WebdriverCSS = function(webdriverInstance, options) {
     this.user = options.user;
     this.api  = options.api;
 
-    /**
-     * create directory structure
-     */
-    fs.exists(this.screenshotRoot, function(exists) {
-        if(!exists) {
-            fs.mkdir(that.screenshotRoot, 0766, function() {
-                fs.mkdir(that.failedComparisonsRoot, 0766);
-            });
-        }
-    });
+    createDirectory(this.screenshotRoot);
+    createDirectory(this.failedComparisonsRoot);
 
     /**
      * add WebdriverCSS command to WebdriverIO instance
@@ -196,6 +188,17 @@ var syncUp = function(done) {
         var form = r.form();
         form.append('gz', fs.createReadStream(screenshotRoot + '.tar.gz'));
 
+    });
+};
+
+/**
+* create directory if it doesn't already exist
+*/
+var createDirectory = function(path) {
+    fs.exists(path, function(exists) {
+        if(!exists) {
+            fs.mkdir(path, 0766);
+        }
     });
 };
 

--- a/lib/webdrivercss.js
+++ b/lib/webdrivercss.js
@@ -36,6 +36,7 @@ var WebdriverCSS = function(webdriverInstance, options) {
     this.warning = [];
     this.resultObject = {};
     this.instance = webdriverInstance;
+    this.updateBaseImages = (options.updateBaseImages !== undefined) ? options.updateBaseImages : true;
 
     /**
      * sync options

--- a/lib/webdrivercss.js
+++ b/lib/webdrivercss.js
@@ -197,7 +197,7 @@ var syncUp = function(done) {
 var createDirectory = function(path) {
     fs.exists(path, function(exists) {
         if(!exists) {
-            fs.mkdir(path, 0766);
+            fs.mkdir(path);
         }
     });
 };


### PR DESCRIPTION
Not sure if this was intended or not, but I would like the ability to keep baseline images within my repository and not have them be renamed each test run. Otherwise the issue that occurs is: 
1. I run the tests and get my baseline images.
2. I force a test failure. But my baseline images get renamed
3. I try to force a test failure again, but this time the test passes because the failed images are now being used as baseline images.

I know that it is preferred to keep baseline images on a separate repo and sync up/down when needed but at the moment that's not viable for my use case. 
