### PR TITLE
Fix screen size

### DIFF
--- a/lib/setScreenWidth.js
+++ b/lib/setScreenWidth.js
@@ -44,7 +44,7 @@ module.exports = function(done) {
 
             }
 
-            if(that.currentArgs.screenWidth.length && (!takenScreenSizes[that.pagename] || takenScreenSizes[that.pagename].indexOf(that.currentArgs.screenWidth[0]) < 0)) {
+            if(that.currentArgs.screenWidth.length && (!takenScreenSizes[that.currentArgs.name] || takenScreenSizes[that.currentArgs.name].indexOf(that.currentArgs.screenWidth[0]) < 0)) {
 
                 /**
                  * set flag to retake screenshot
@@ -61,10 +61,10 @@ module.exports = function(done) {
                     /**
                      * cache already taken screenshot / screenwidth combinations
                      */
-                    if(!takenScreenSizes[that.pagename]) {
-                        takenScreenSizes[that.pagename] = [that.newScreenSize.width];
+                    if(!takenScreenSizes[that.currentArgs.name]) {
+                        takenScreenSizes[that.currentArgs.name] = [that.newScreenSize.width];
                     } else {
-                        takenScreenSizes[that.pagename].push(that.newScreenSize.width);
+                        takenScreenSizes[that.currentArgs.name].push(that.newScreenSize.width);
                     }
 
                     /**

--- a/test/spec/screenWidth.js
+++ b/test/spec/screenWidth.js
@@ -79,3 +79,45 @@ describe('WebdriverCSS captures shots with different screen widths', function() 
     after(afterHook);
 
 });
+
+describe('WebdriverCSS captures shots with different screen widths', function() {
+
+    before(function(done) {
+
+        this.browser = WebdriverIO.remote(capabilities);
+
+        // init plugin
+        WebdriverCSS.init(this.browser);
+
+        this.browser
+            .init()
+            .url(testurl)
+            .windowHandleSize({ width: 999, height: 999 })
+            .webdrivercss('screenWidthTest', [
+                {
+                    name: 'test_three',
+                    screenWidth: [320,480,640,1024]
+                },{
+                    name: 'test_four',
+                    screenWidth: [320,480,640,1024]
+                }
+            ])
+            .call(done);
+    });
+
+    /**
+     * 12 pictures get taken
+     * - 4 + 4 cropped images of the element for each screen resolution
+     * - 4 screenshots of the whole website for each screen resolution
+     */
+    it('if 4 screen widths are given and 2 elements captured, it should have taken 12 shots', function(done) {
+        glob('webdrivercss/*.png', function(err,files) {
+            should.not.exist(err);
+            files.should.have.length(12);
+            done();
+        });
+    });
+
+    after(afterHook);
+
+});


### PR DESCRIPTION
This pull request fixes an issue where if you set the screenWidth to be the same for multiple elements the screenshots for the second element aren't taken, instead you end up in an infinite loop talking screenshots with the name "screenWidthTest.test_four.undefined.png"

```
.webdrivercss('screenWidthTest', [
    {
        elem: '.test_three',
        name: 'test_three',
        screenWidth: [320,480,640,1024]
    },{
        elem: '.test_four',
        name: 'test_four',
        screenWidth: [320,480,640,1024]
   }
])
```

I have written a test but I could get any of the test to run so I'm not sure I have written it correctly.

Thanks,
David
