### PR TITLE
Applitools API key passed as a query string argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ build/Release
 # see https://npmjs.org/doc/faq.html#Should-I-check-my-node_modules-folder-into-git
 node_modules
 test/site/components
+
+#jetbrains IDE
+.idea

--- a/README.md
+++ b/README.md
@@ -449,6 +449,13 @@ It provides even a web interface for before/after comparison and stuff like this
 Please fork, add specs, and send pull requests! In lieu of a formal styleguide, take care to
 maintain the existing coding style.
 
+Default driver instance used for testing is [PhantomJS](https://github.com/ariya/phantomjs), so you need to either have
+it installed, or change it to your preferred driver (e.g., Firefox) in the `desiredCapabilities` in the `bootstrap.js`
+file under the `test` folder.
+
+You also need a web server to serve the "site" files and have the root folder set to "webdrivercss". We use the
+[http-server package](https://www.npmjs.org/package/http-server).
+
 ## Release History
 
 * 2013-03-28   v0.1.0   first release

--- a/lib/cropImage.js
+++ b/lib/cropImage.js
@@ -75,6 +75,7 @@ module.exports = function(res, done) {
             }
 
             request({
+                qs: {apiKey: that.self.key},
                 url: that.self.host + '/api/sessions/running/' + that.self.sessionId,
                 method: 'POST',
                 headers: that.self.headers,

--- a/lib/endSession.js
+++ b/lib/endSession.js
@@ -31,6 +31,7 @@ module.exports = function(done) {
             }
 
             return request({
+                qs: {apiKey: that.self.key},
                 url: that.self.host + '/api/sessions/running/' + that.self.sessionId,
                 method: 'DELETE',
                 headers: that.self.headers,

--- a/lib/startSession.js
+++ b/lib/startSession.js
@@ -43,6 +43,7 @@ module.exports = function() {
         function(cb) {
             request({
                 url: that.self.host + '/api/sessions/running',
+                qs: {apiKey: that.self.key},
                 method: 'POST',
                 json: {
                     'startInfo': {

--- a/lib/webdrivercss.js
+++ b/lib/webdrivercss.js
@@ -42,7 +42,6 @@ var WebdriverCSS = function(webdriverInstance, options) {
     this.key  = options.key;
     this.host = 'https://eyessdk.applitools.com';
     this.headers = {
-        'Authorization': 'Basic ' + new Buffer(':' + this.key).toString('base64'),
         'Accept': 'application/json',
         'Content-Type': 'application/json'
     };

--- a/test/spec/sync.js
+++ b/test/spec/sync.js
@@ -88,7 +88,6 @@ describe('WebdriverCSS should be able to', function() {
             isSessionClosed = false;
 
         var headers = {
-            'Authorization': 'Basic ' + new Buffer(':' + key).toString('base64'),
             'Accept': 'application/json',
             'Content-Type': 'application/json'
         }
@@ -97,7 +96,7 @@ describe('WebdriverCSS should be able to', function() {
          * mock session initiatlization
          */
         nock(applitoolsHost, {reqheaders: headers})
-            .post('/api/sessions/running')
+            .post('/api/sessions/running?apiKey=' + key)
             .reply(200, function(uri, requestBody) {
                 isSessionInitiated = true;
                 return {
@@ -110,7 +109,7 @@ describe('WebdriverCSS should be able to', function() {
          * mock image sync
          */
         nock(applitoolsHost, {reqheaders: headers})
-            .post('/api/sessions/running/' + fakeSessionId)
+            .post('/api/sessions/running/' + fakeSessionId + '?apiKey=' + key)
             .reply(200, function(uri, requestBody) {
                 hasSyncedImage = true;
                 return { 'asExpected' : true };
@@ -120,7 +119,7 @@ describe('WebdriverCSS should be able to', function() {
          * mock session end
          */
         nock(applitoolsHost, {reqheaders: headers})
-            .delete('/api/sessions/running/' + fakeSessionId)
+            .delete('/api/sessions/running/' + fakeSessionId + '?apiKey=' + key)
             .reply(200, function(uri, requestBody) {
                 isSessionClosed = true;
                 return {'steps':1,'matches':1,'mismatches':0,'missing':0};


### PR DESCRIPTION
Applitools API key is now passed as a query string argument instead of using authorization header. This avoids problems encountered by users who are behind a proxy server.  
