### PR TITLE
Setting the screen width synchronously 

### DIFF
--- a/lib/setScreenWidth.js
+++ b/lib/setScreenWidth.js
@@ -79,7 +79,7 @@ module.exports = function(done) {
                              /**
                               * wait until browser got resized before continue
                               */
-                             .executeAsync(function(newScreenSize, cb) {
+                             .execute(function(newScreenSize, cb) {
                                 var timeout = null;
                                 function checkScreenWidth() {
                                     if(Math.max(document.documentElement.clientWidth, window.innerWidth || 0) === newScreenSize.width) {


### PR DESCRIPTION
I was finding that with the screen resizing with `executeAsync`, the function would quickly change the browser width but never call cb. The code continued only because this function timed out. I had this problem with both browserstack and local browsers.

This problem went away when using `execute`.

I'm not sure how we should test this, or if this is even the right approach. I just wanted to get this PR up for discussion. 
