### PR TITLE
Small typo in primary example

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ var client = require('webdriverio').remote({
     desiredCapabilities: {
         browserName: 'phantomjs'
     }
-});
+}).init();
 
 // initialise WebdriverCSS for `client` instance
 require('webdrivercss').init(client, {


### PR DESCRIPTION
I was looking into implementing this library and had a heck of a time with setup. I believe the culprit was the lack of the first `.init()` in the example here.

I might be wrong but wanted to at least open this PR for discussion. If I'm mistaken I'd still like to clear up how I went off-track and try to update docs accordingly.
