### PR TITLE
Init webdriver inside mocha setup function to avoid BrowserStack timeouts.

### DIFF
--- a/examples/webdrivercss.browserstack.with.mocha.js
+++ b/examples/webdrivercss.browserstack.with.mocha.js
@@ -52,14 +52,21 @@ var client = webdriverio.remote({
   port: 80,
   user: config.browserstack.user,
   key: config.browserstack.key
-}).init();
-
-// Initialize webdrivercss
-webdrivercss.init(client, options.webdrivercss);
+});
 
 // Run the test
 describe('Win7 / IE9: My Component @ 1024', function () {
   this.timeout(600000);
+
+  // If multiple tests are run by mocha, use its setup function to initialize
+  // webdriverio and webdrivercss. Otherwise, BrowserStack connections might
+  // timeout while you wait for the first few tests to run.
+  before(function(){
+    // Initialize webdriverio
+    client.init();
+    // Initialize webdrivercss
+    webdrivercss.init(client, options.webdrivercss);
+  });
 
   it('should look the same', function (done) {
     client


### PR DESCRIPTION
As mentioned in https://github.com/webdriverio/webdrivercss/pull/81#issuecomment-111206390 this small change will save people a big debugging headache once they have more than 2 or 3 tests being initiated by mocha.
