### PR TITLE
Fixed exclude getBoundingClientRect on IE8

### DIFF
--- a/lib/getPageInfo.js
+++ b/lib/getPageInfo.js
@@ -160,8 +160,8 @@ module.exports = function(done) {
                         excludeRect.push({
                             x0: elemRect.left,
                             y0: elemRect.top,
-                            x1: elemRect.left + elemRect.width,
-                            y1: elemRect.top + elemRect.height
+                            x1: elemRect.right,
+                            y1: elemRect.bottom
                         });
                     });
                 });


### PR DESCRIPTION
Webdrivercss crashes when using excludes on IE8.
On IE8 the object returned by `getBoundingClientRect` [lacks](http://caniuse.com/#search=getBoundingClientRect) `width` and `height` properties.
The PR fixes this issue.
