### PR TITLE
Don't re-enable scrollbars after capture

### DIFF
--- a/lib/documentScreenshot.js
+++ b/lib/documentScreenshot.js
@@ -231,16 +231,6 @@ module.exports = function documentScreenshot(fileName) {
          */
         function(cb) {
             self.execute(scrollFn, 0, 0, cb);
-        },
-
-        /**
-         * enable scrollbars again
-         */
-        function(res, cb) {
-            response.execute.push(res);
-            self.execute(function() {
-                document.body.style.overflow = 'visible';
-            }, cb);
         }
     ], function(err) {
         callback(err, null, response);


### PR DESCRIPTION
Re-enabling scrollbars may effect the placement of excluded rectangles.

fixes #93
