### PR TITLE
Save a new baseline image, if one doesn't already exist

### DIFF
--- a/lib/saveImageDiff.js
+++ b/lib/saveImageDiff.js
@@ -74,10 +74,14 @@ module.exports = function(imageDiff,done) {
                 }
             },
             /**
-             * keep newest screenshot
+             * Save a new baseline image, if one doesn't already exist.
+             *
+             * If one does exist, we delete the temporary regression.
              */
             function(done) {
-                fs.rename(that.regressionPath, that.baselinePath, done);
+                fs.exists(that.baselinePath, function(exists) {
+                    return !!exists ? fs.unlink(that.regressionPath, done) : fs.rename(that.regressionPath, that.baselinePath, done);
+                });
             }
         ], function(err) {
 


### PR DESCRIPTION
If the baseline already exists, and there's no regression, we shouldn't re-save it.
