### PR TITLE
Add more emphasis to wdio 3.0 incompatability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 WebdriverCSS [![Version](http://img.shields.io/badge/version-v1.1.6-brightgreen.svg)](https://www.npmjs.org/package/webdrivercss) [![Build Status](https://travis-ci.org/webdriverio/webdrivercss.png?branch=master)](https://travis-ci.org/webdriverio/webdrivercss) [![Coverage Status](https://coveralls.io/repos/webdriverio/webdrivercss/badge.png?branch=master)](https://coveralls.io/r/webdriverio/webdrivercss?branch=master)
 ============
 
-__Note:__ WebdriverCSS isn't yet compatible with WebdriverIO `v3.0`. We are currently working on it to make that happen soon. So stay tuned.
+---
+
+> **_Note:_ WebdriverCSS isn't yet compatible with WebdriverIO `v3.0`.** We are currently working on it to make that happen soon. So stay tuned.
+
+---
 
 __CSS regression testing in WebdriverIO__. This plugin is an automatic visual regression-testing
 tool for [WebdriverIO](http://webdriver.io). It was inspired by [James Cryer's](https://github.com/jamescryer)


### PR DESCRIPTION
I missed the disclaimer about the wdio 3.0 incompatibility, so figured some more emphasis on the readme text would help others avoid missing it as well.

Current:
![image](https://cloud.githubusercontent.com/assets/706039/9334619/3f3913a8-4595-11e5-94cb-aff814e7399a.png)

New:
![image](https://cloud.githubusercontent.com/assets/706039/9334613/386a6856-4595-11e5-8303-ef67d45a4cf2.png)
