### PR TITLE
Set scroll height of body before hiding overflow

### DIFF
--- a/lib/documentScreenshot.js
+++ b/lib/documentScreenshot.js
@@ -101,6 +101,7 @@ module.exports = function documentScreenshot(fileName) {
                 /**
                  * remove scrollbars
                  */
+                document.body.style.height = document.documentElement.scrollHeight + 'px';
                 document.body.style.overflow = 'hidden';
 
                 /**


### PR DESCRIPTION
This fixes a bug in my environment where setting `overflow: visible` would cause the majority of my app to be hidden, defeating the purpose of taking the screenshots :)

I've validated this fix by using it on my app, along with running the base webdrivercss unit tests. Everything seems to work fine.  
