### PR TITLE
Fix image diff corner case when misMatchPercentage equals misMatchTolerance

### DIFF
--- a/lib/saveImageDiff.js
+++ b/lib/saveImageDiff.js
@@ -94,7 +94,7 @@ module.exports = function(imageDiff,done) {
                 misMatchPercentage: misMatchTolerance,
                 isExactSameImage: misMatchTolerance === 0,
                 isSameDimensions: imageDiff.isSameDimensions,
-                isWithinMisMatchTolerance: that.misMatchTolerance > misMatchTolerance
+                isWithinMisMatchTolerance: true
             });
 
             done(err);

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -13,6 +13,7 @@ capabilities = {logLevel: 'silent',desiredCapabilities:{browserName: 'phantomjs'
 testurl = 'http://localhost:8080/test/site/index.html';
 testurlTwo = 'http://localhost:8080/test/site/two.html';
 testurlThree = 'http://localhost:8080/test/site/three.html';
+testurlFour = 'http://localhost:8080/test/site/four.html';
 
 /**
  * set some fix test variables

--- a/test/site/four.html
+++ b/test/site/four.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>four</title>
+</head>
+<body>
+    <div id="container" style="width: 200px; height: 10px; background: white">
+        <div id="difference" style="width: 1px; height: 1px; background: red"></div>
+    </div>
+</body>
+</html>

--- a/test/spec/imageComparison.js
+++ b/test/spec/imageComparison.js
@@ -206,6 +206,40 @@ describe('WebdriverCSS compares images and exposes information about CSS regress
 
     });
 
+    describe('should match an image when match percentage is equal to tolerance', function() {
+        var resultObject = {};
+
+        before(function(done) {
+            this.browser
+                .url(testurlFour)
+                .webdrivercss('comparisonTest', {
+                    elem: '#container',
+                    name: 'test-equal'
+                }, function(err,res) {
+                    should.not.exist(err);
+                })
+                .execute(function() {
+                    document.querySelector('#difference').style.backgroundColor = 'white';
+                }, [])
+                .webdrivercss('comparisonTest', {
+                    elem: '#container',
+                    name: 'test-equal'
+                }, function(err,res) {
+                    should.not.exist(err);
+                    resultObject = res['test-equal'][0];
+                })
+                .call(done);
+        });
+
+        it('should be within tolerance', function() {
+            resultObject.misMatchPercentage.should.be.a('number');
+            resultObject.misMatchPercentage.should.equal(0.05);
+            resultObject.isExactSameImage.should.equal(false);
+            resultObject.isWithinMisMatchTolerance.should.equal(true);
+        });
+
+    });
+
     after(afterHook);
 
 });


### PR DESCRIPTION
The issue is that when `misMatchPercentage` is equal to `misMatchTolerance` the `isWithinMisMatchTolerance` property of the result is `false` even though the `message` says the tolerance isn't exceeded.

After the fix the `isWithinMisMatchTolerance` will be `true` in this scenario.
