### PR TITLE
Remove tarball file after sync

### DIFF
--- a/lib/syncImages.js
+++ b/lib/syncImages.js
@@ -68,7 +68,8 @@ var syncDown = function(done) {
  */
 var syncUp = function(done) {
     var screenshotRoot = this.screenshotRoot,
-        args = { url: this.api };
+        args = { url: this.api },
+        tarballPath = screenshotRoot + '.tar.gz';
 
     if(typeof this.user === 'string' && typeof this.key === 'string') {
         args.auth = {
@@ -77,17 +78,20 @@ var syncUp = function(done) {
         };
     }
 
-    new targz().compress(screenshotRoot, screenshotRoot + '.tar.gz', function(err){
+    new targz().compress(screenshotRoot, tarballPath, function(err){
 
         /*istanbul ignore if*/
         if(err) {
             return done(new Error(err));
         }
 
-        var r = request.post(args, done);
+        var r = request.post(args, function () {
+            rimraf.sync(tarballPath);
+            done();
+        });
 
         var form = r.form();
-        form.append('gz', fs.createReadStream(screenshotRoot + '.tar.gz'));
+        form.append('gz', fs.createReadStream(tarballPath));
 
     });
 };

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "rimraf": "^2.3.2",
     "tar": "^2.1.0",
     "fs-extra": "^0.18.2",
-    "tar.gz": "^0.1.1"
+    "tar.gz": "^1.0.1"
   },
   "devDependencies": {
     "chai": "^2.3.0",

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -21,7 +21,6 @@ screenshotRootDefault = 'webdrivercss';
 failedComparisonsRootDefault = 'webdrivercss/diff';
 screenshotRootCustom = '__screenshotRoot__';
 failedComparisonsRootCustom = '__failedComparisonsRoot__';
-repositorytargz = 'webdrivercss.tar.gz';
 
 afterHook = function(done) {
 
@@ -35,8 +34,7 @@ afterHook = function(done) {
         function(done) { fs.remove(failedComparisonsRootDefault,done); },
         function(done) { fs.remove(screenshotRootDefault,done); },
         function(done) { fs.remove(failedComparisonsRootCustom,done); },
-        function(done) { fs.remove(screenshotRootCustom,done); },
-        function(done) { fs.remove(repositorytargz,done); }
+        function(done) { fs.remove(screenshotRootCustom,done); }
     ], done);
 
 };

--- a/test/spec/sync.js
+++ b/test/spec/sync.js
@@ -72,6 +72,9 @@ describe('WebdriverCSS should be able to', function() {
                 .sync()
                 .call(function() {
                     expect(madeRequest).to.be.true;
+
+                    // should delete the tarball file after syncing
+                    expect(fs.existsSync(path.join(__dirname, '..', '..', 'webdrivercss.tar.gz'))).to.be.false;
                 })
                 .call(done);
 


### PR DESCRIPTION
The removes the tarball file artifact after syncing. 
# Testing
- Ensure you have the latest dependencies with `rm -rf node_modules && npm install`
- Run the unit test suite, ensuring all tests pass
- After running, validate the `webdrivercss.tar.gz` file doesn't exist
## Notes
- I was looking at a way to pipe the stream from `targz()` to the form (in lieu of creating a file), but just don't know enough about it to figure out the sync error I was getting. Going to see if I can try this again when I get more free time. 
- The upgrade to 1.0.1 for `tar.gz` isn't necessary, but thought it's worth updating anyway. 
