### PR TITLE
Add webdriverio 3 API compatibility

### DIFF
--- a/lib/asyncCallback.js
+++ b/lib/asyncCallback.js
@@ -4,7 +4,7 @@
  * run workflow again or execute callback function
  */
 
-var workflow = require('./workflow.js'),
+var workflow = require('./workflow.js').workflow,
     endSession = require('./endSession.js');
 
 module.exports = function(err) {

--- a/lib/documentScreenshot.js
+++ b/lib/documentScreenshot.js
@@ -29,22 +29,20 @@ var async = require('async'),
     gm = require('gm'),
     rimraf = require('rimraf'),
     generateUUID = require('./generateUUID.js'),
-    path = require('path');
+    path = require('path'),
+    q = require('q');
 
 module.exports = function documentScreenshot(fileName) {
+    var defer = q.defer();
 
     var ErrorHandler = this.instance.ErrorHandler;
-
-    /*!
-     * make sure that callback contains chainit callback
-     */
-    var callback = arguments[arguments.length - 1];
 
     /*!
      * parameter check
      */
     if (typeof fileName !== 'string') {
-        return callback(new ErrorHandler.CommandError('number or type of arguments don\'t agree with saveScreenshot command'));
+        defer.reject(new ErrorHandler.CommandError('number or type of arguments don\'t agree with saveScreenshot command'));
+        return defer.promise;
     }
 
     var self = this.instance,
@@ -118,7 +116,10 @@ module.exports = function documentScreenshot(fileName) {
                     documentWidth: document.documentElement.scrollWidth,
                     documentHeight: document.documentElement.scrollHeight
                 };
-            }, cb);
+            })
+            .then(function (res) {
+                cb(null, res);
+            });
         },
 
         /*!
@@ -177,13 +178,18 @@ module.exports = function documentScreenshot(fileName) {
                          * scroll to next area
                          */
                         function() {
+                            var callback = arguments[arguments.length - 1];
                             self.execute(scrollFn,
                                 currentXPos * response.execute[0].value.screenWidth,
-                                currentYPos * response.execute[0].value.screenHeight,
-                                function(val, res) {
-                                    response.execute.push(res);
-                                }
-                            ).pause(100).call(arguments[arguments.length - 1]);
+                                currentYPos * response.execute[0].value.screenHeight
+                            )
+                            .then(function (res) {
+                                response.execute.push(res);
+                            })
+                            .pause(100)
+                            .then(function () {
+                                callback();
+                            });
                         }
 
                     ], finishedScreenshot);
@@ -231,10 +237,19 @@ module.exports = function documentScreenshot(fileName) {
          * scroll back to start position
          */
         function(cb) {
-            self.execute(scrollFn, 0, 0, cb);
+            self
+                .execute(scrollFn, 0, 0)
+                .then(function () {
+                    cb();
+                });
         }
     ], function(err) {
-        callback(err, null, response);
+        if (err) {
+            defer.reject(err);
+        } else {
+            defer.resolve();
+        }
     });
 
+    return defer.promise
 };

--- a/lib/endSession.js
+++ b/lib/endSession.js
@@ -20,7 +20,10 @@ module.exports = function(done) {
             that.instance.windowHandleSize({
                 width: that.self.defaultScreenDimension.width,
                 height: that.self.defaultScreenDimension.height
-            }, cb);
+            })
+                .then(function (res) {
+                    cb(null, res);
+                });
         },
         /**
          * end session when using applitools

--- a/lib/getPageInfo.js
+++ b/lib/getPageInfo.js
@@ -72,8 +72,10 @@ module.exports = function(done) {
                     screenWidth: Math.max(document.documentElement.clientWidth, window.innerWidth || 0),
                     screenHeight: Math.max(document.documentElement.clientHeight, window.innerHeight || 0)
                 };
-
-            }, cb);
+            })
+            .then(function (pageInfo) {
+                cb(null, pageInfo);
+            });
         },
 
         /**
@@ -101,7 +103,11 @@ module.exports = function(done) {
                         left: boundingRect.left
                     }
                 };
-            }, cb);
+            })
+            .then(function (elementInfo) {
+                // ! TODO check response and its schema being correct here
+                cb(null, elementInfo, response);
+            });
         },
 
         /**
@@ -168,7 +174,10 @@ module.exports = function(done) {
 
                 return excludeRect;
 
-            }, done);
+            })
+            .then(function (excludeRect) {
+                done(null, excludeRect);
+            });
         }
     ], function(err, excludeElements) {
 

--- a/lib/makeScreenshot.js
+++ b/lib/makeScreenshot.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var q = require('q');
+
 /**
  * make screenshot via [GET] /session/:sessionId/screenshot
  */
@@ -8,7 +10,7 @@ var modifyElements = function(elements, style, value) {
         return;
     }
 
-    this.instance.selectorExecute(elements, function() {
+    return this.instance.selectorExecute(elements, function() {
         var args = Array.prototype.slice.call(arguments).filter(function(n){ return !!n; }),
             style = args[args.length - 2],
             value = args[args.length - 1];
@@ -24,6 +26,7 @@ var modifyElements = function(elements, style, value) {
 };
 
 module.exports = function(done) {
+    var that = this;
 
     /**
      * take actual screenshot in given screensize just once
@@ -57,18 +60,28 @@ module.exports = function(done) {
     /**
      * hide / remove elements
      */
-    modifyElements.call(this, hiddenElements, 'visibility', 'hidden');
-    modifyElements.call(this, removeElements, 'display', 'none');
-
-    /**
-     * take 100ms pause to give browser time for rendering
-     */
-    this.instance.pause(100).saveDocumentScreenshot(this.screenshot, done);
-
-    /**
-     * make hidden elements visible again
-     */
-    modifyElements.call(this, hiddenElements, 'visibility', '');
-    modifyElements.call(this, removeElements, 'display', '');
+    q.all([
+        modifyElements.call(that, hiddenElements, 'visibility', 'hidden'),
+        modifyElements.call(that, removeElements, 'display', 'none')
+    ])
+        .then(function () {
+            /**
+             * take 100ms pause to give browser time for rendering
+             */
+            return that.instance.pause(100).saveDocumentScreenshot(that.screenshot);
+        })
+        .then(function () {
+            /**
+             * make hidden elements visible again
+             */
+            return q.all([
+                modifyElements.call(that, hiddenElements, 'visibility', ''),
+                modifyElements.call(that, removeElements, 'display', '')
+            ]);
+        })
+        .then(function () {
+            done();
+        })
+        .done();
 
 };

--- a/lib/setScreenWidth.js
+++ b/lib/setScreenWidth.js
@@ -19,10 +19,11 @@ module.exports = function(done) {
          */
         function(cb) {
             if(!that.self.defaultScreenDimension && that.screenWidth && that.screenWidth.length) {
-                that.instance.windowHandleSize(function(err,res) {
-                    that.self.defaultScreenDimension = res.value;
-                    cb();
-                });
+                that.instance.windowHandleSize()
+                    .then(function(res) {
+                        that.self.defaultScreenDimension = res.value;
+                        cb();
+                    });
             } else {
                 cb();
             }

--- a/lib/startSession.js
+++ b/lib/startSession.js
@@ -29,15 +29,16 @@ module.exports = function() {
                     screenWidth: Math.max(document.documentElement.clientWidth, window.innerWidth || 0),
                     documentHeight: document.documentElement.scrollHeight
                 };
-            }, function(err, res) {
-                that.useragent = res.value.useragent;
-                that.displaySize = {
-                    width: that.screenWidth && that.screenWidth.length ? that.screenWidth[0] : res.value.screenWidth,
-                    height: res.value.documentHeight
-                };
+            })
+                .then(function(res) {
+                    that.useragent = res.value.useragent;
+                    that.displaySize = {
+                        width: that.screenWidth && that.screenWidth.length ? that.screenWidth[0] : res.value.screenWidth,
+                        height: res.value.documentHeight
+                    };
 
-                return cb();
-            });
+                    return cb();
+                });
         },
 
         /**

--- a/lib/syncImages.js
+++ b/lib/syncImages.js
@@ -5,7 +5,8 @@ var fs = require('fs-extra'),
     zlib = require('zlib'),
     targz = require('tar.gz'),
     rimraf = require('rimraf'),
-    request = require('request');
+    request = require('request'),
+    q = require('q');
 
 /**
  * sync down
@@ -105,6 +106,8 @@ var syncUp = function(done) {
  */
 module.exports = function(done) {
 
+    var defer = q.defer();
+
     if(!this.api) {
         return done(new Error('No sync options specified! Please provide an api path and user/key (optional).'));
     }
@@ -116,11 +119,11 @@ module.exports = function(done) {
 
         /*istanbul ignore next*/
         if(err || (httpResponse && httpResponse.statusCode !== 200)) {
-            return done(new Error(err || body));
+            return defer.reject(new Error(err || body));
         }
 
-        done();
+        defer.resolve();
 
     });
-    return this;
+    return defer.promise;
 };

--- a/lib/viewportScreenshot.js
+++ b/lib/viewportScreenshot.js
@@ -7,22 +7,20 @@
  */
 
 var async = require('async'),
-    gm = require('gm');
+    gm = require('gm'),
+    q = require('q');
 
 module.exports = function viewportScreenshot(fileName) {
 
     var ErrorHandler = this.instance.ErrorHandler;
-
-    /*!
-     * make sure that callback contains chainit callback
-     */
-    var callback = arguments[arguments.length - 1];
+    var defer = q.defer();
 
     /*!
      * parameter check
      */
     if (typeof fileName !== 'string') {
-        return callback(new ErrorHandler.CommandError('number or type of arguments don\'t agree with saveScreenshot command'));
+        defer.reject(new ErrorHandler.CommandError('number or type of arguments don\'t agree with saveScreenshot command'));
+        return defer.promise;
     }
 
     var self = this.instance,
@@ -95,8 +93,14 @@ module.exports = function viewportScreenshot(fileName) {
         }
     ], function(err) {
 
-        callback(err, null, response);
+        if (err) {
+            return defer.reject(err);
+        }
+
+        defer.resolve(response);
 
     });
+
+    return defer.promise;
 
 };

--- a/lib/viewportScreenshot.js
+++ b/lib/viewportScreenshot.js
@@ -56,7 +56,13 @@ module.exports = function viewportScreenshot(fileName) {
          * get scroll position
          */
         function(cb) {
-            self.execute(getScrollingPosition, null, cb);
+            self.execute(getScrollingPosition, null)
+                .then(function (res) {
+                    cb(null, res);
+                })
+                .catch(function (err) {
+                    cb(err);
+                });
         },
 
         /*!
@@ -70,11 +76,23 @@ module.exports = function viewportScreenshot(fileName) {
                     screenWidth: Math.max(document.documentElement.clientWidth, window.innerWidth || 0),
                     screenHeight: Math.max(document.documentElement.clientHeight, window.innerHeight || 0)
                 };
-            }, cb);
+            })
+                .then(function (res) {
+                    cb(null, res);
+                })
+                .catch(function (err) {
+                    cb(err);
+                });
         },
         function(res, cb) {
             response.execute.push(res);
-            self.screenshot(cb);
+            self.screenshot()
+                .then(function (screenshotRes) {
+                    cb(null, screenshotRes);
+                })
+                .catch(function (err) {
+                    cb(err);
+                });
         },
         function(res, cb) {
             response.screenshot = res;

--- a/lib/webdrivercss.js
+++ b/lib/webdrivercss.js
@@ -69,10 +69,10 @@ var WebdriverCSS = function(webdriverInstance, options) {
     /**
      * add WebdriverCSS command to WebdriverIO instance
      */
-    this.instance.addCommand('saveViewportScreenshot', viewportScreenshot.bind(this));
-    this.instance.addCommand('saveDocumentScreenshot', documentScreenshot.bind(this));
-    this.instance.addCommand('webdrivercss', workflow.bind(this));
-    this.instance.addCommand('sync', syncImages.bind(this));
+    this.instance.addCommand('saveViewportScreenshot', viewportScreenshot.bind(this), true);
+    this.instance.addCommand('saveDocumentScreenshot', documentScreenshot.bind(this), true);
+    this.instance.addCommand('webdrivercss', workflow.promise.bind(this), true);
+    this.instance.addCommand('sync', syncImages.bind(this), true);
 
     return this;
 };

--- a/lib/workflow.js
+++ b/lib/workflow.js
@@ -5,9 +5,21 @@
  */
 
 var async = require('async');
+var q = require('q');
 
-module.exports = function(pagename, args) {
+function wrappedWorkflow(pagename, args) {
+    var defer = q.defer();
 
+    function cb(err, result) {
+        defer.resolve(result);
+    }
+
+    workflow.call(this, pagename, args, cb);
+
+    return defer.promise;
+}
+
+function workflow(pagename, args) {
     /*!
      * make sure that callback contains chainit callback
      */
@@ -126,6 +138,10 @@ module.exports = function(pagename, args) {
          * run workflow again or execute callback function
          */
         require('./asyncCallback.js').bind(context)
-
     );
+}
+
+module.exports = {
+    workflow: workflow,
+    promise: wrappedWorkflow
 };

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "glob": "^5.0.5",
     "gm": "^1.17.0",
     "node-resemble-js": "0.0.4",
+    "q": "^1.4.1",
     "request": "^2.55.0",
     "rimraf": "^2.3.2",
     "tar": "^2.1.0",
@@ -33,7 +34,7 @@
     "mocha": "^2.2.4",
     "mocha-istanbul": "^0.2.0",
     "nock": "^1.7.1",
-    "webdriverio": "^2.4.5"
+    "webdriverio": "^3.2.1"
   },
   "keywords": [
     "webdriverjs",

--- a/test/spec/imageCapturing.js
+++ b/test/spec/imageCapturing.js
@@ -24,7 +24,8 @@ describe('WebdriverCSS captures desired parts of a website as screenshot with sp
                 .webdrivercss('testWithoutParameter', { name: 'withoutParams'})
                 .execute(function(){
                     return document.body.clientHeight;
-                }, function(err,res) {
+                })
+                .then(function(res) {
                     documentHeight = res.value;
                 })
                 .call(done);


### PR DESCRIPTION
Hello!

we saw that you're already working on webdriverio 3 compatibility on the 1.2 version branch, but it's a huge rework to migrate from async to q in one release. As we wanted to use the improvements of wdio 3 in our projects we created an implementation on our webdrivercss fork, that just changes the minimum amount of code needed to update wdio. Basically we changed the following things:
1. Update calls to wdio to reflect the changes done in version 3
2. Change custom commands to return q promises instead of using the callback needed by wdio 2
Naturally it's a **breaking change** for users of webdrivercss, because of the API differences in wdio.

Of course we wanted to share our work with you and maybe you can use it as base to get wdio 3 support out soon. Keep up the great work :+1: 

Best regards
@sagold & @benurb
