### PR TITLE
Make screenshots high dpi aware

### DIFF
--- a/lib/documentScreenshot.js
+++ b/lib/documentScreenshot.js
@@ -116,7 +116,8 @@ module.exports = function documentScreenshot(fileName) {
                     screenWidth: Math.max(document.documentElement.clientWidth, window.innerWidth || 0),
                     screenHeight: Math.max(document.documentElement.clientHeight, window.innerHeight || 0),
                     documentWidth: document.documentElement.scrollWidth,
-                    documentHeight: document.documentElement.scrollHeight
+                    documentHeight: document.documentElement.scrollHeight,
+                    devicePixelRatio: window.devicePixelRatio
                 };
             }, cb);
         },
@@ -157,7 +158,15 @@ module.exports = function documentScreenshot(fileName) {
                          */
                         function(res, cb) {
                             var file = tmpDir + '/' + currentXPos + '-' + currentYPos + '.png';
-                            gm(new Buffer(res.value, 'base64')).crop(response.execute[0].value.screenWidth, response.execute[0].value.screenHeight, 0, 0).write(file, cb);
+                            var image = gm(new Buffer(res.value, 'base64'));
+
+                            if (response.execute[0].value.devicePixelRatio > 1) {
+                                var percent = 100 / response.execute[0].value.devicePixelRatio;
+                                image.resize(percent, percent, "%");
+                            }
+
+                            image.crop(response.execute[0].value.screenWidth, response.execute[0].value.screenHeight, 0, 0);
+                            image.write(file, cb);
                             response.screenshot.push(res);
 
                             if (!cropImages[currentXPos]) {


### PR DESCRIPTION
Hello!

this PR scales down screenshots taken on high DPI displays (e.g. apple's retina) to their logical dimensions before processing them further. This fixes images cut in half/thirds on this type of display.

The other solution discussed in #52 (multiplying all pixel values with the physical/logical pixel ratio) is probably good, too, but harder to implement. This PR can be a first step as it at least prevents screenshots from being cut in half :smile: 

Best regards
Ben
