### PR TITLE
Replace falsy check of coordinates with proper numeric check

### DIFF
--- a/lib/cropImage.js
+++ b/lib/cropImage.js
@@ -16,16 +16,21 @@ module.exports = function(res, done) {
         shot = gm(this.screenshot).quality(100),
         cropDim;
 
-    if (this.currentArgs.x && this.currentArgs.y && this.currentArgs.width && this.currentArgs.height) {
+    var x = parseInt(this.currentArgs.x, 10);
+    var y = parseInt(this.currentArgs.y, 10);
+    var width = parseInt(this.currentArgs.width, 10);
+    var height = parseInt(this.currentArgs.height, 10);
+
+    if (!isNaN(x) && !isNaN(y) && !isNaN(width) && !isNaN(height)) {
 
         /**
          * crop image with given arguments
          */
         cropDim = {
-            x: this.currentArgs.x - res.scrollPos.x,
-            y: this.currentArgs.y - res.scrollPos.y,
-            width: this.currentArgs.width,
-            height: this.currentArgs.height
+            x: x - res.scrollPos.x,
+            y: y - res.scrollPos.y,
+            width: width,
+            height: height
         };
 
         exclude(shot, excludeRect);
@@ -39,8 +44,8 @@ module.exports = function(res, done) {
         cropDim = {
             x: res.elemBounding.left + (res.elemBounding.width / 2),
             y: res.elemBounding.top + (res.elemBounding.height / 2),
-            width: typeof this.currentArgs.width !== 'undefined' ? this.currentArgs.width : res.elemBounding.width,
-            height: typeof this.currentArgs.height !== 'undefined' ? this.currentArgs.height : res.elemBounding.height
+            width: isNaN(width) ? res.elemBounding.width : width,
+            height: isNaN(height) ? res.elemBounding.height : height
         };
 
         exclude(shot, excludeRect);


### PR DESCRIPTION
Hi,

there is a little problem with the check for the cropping parameters. It was doing a falsy check instead of a proper numeric check, so that the following config did not work, because of 0 for x/y resolving to false:

``` js
{
  name: "name",
  x: 0,
  y: 0,
  width: 100,
  height: 100
}
```

This PR fixes the check :smile: 

Best regards,
Ben
