### PR TITLE
Scrollbars on first screenshot

### DIFF
--- a/lib/documentScreenshot.js
+++ b/lib/documentScreenshot.js
@@ -96,30 +96,47 @@ module.exports = function documentScreenshot(fileName) {
          * prepare page scan
          */
         function() {
-            var cb = arguments[arguments.length - 1];
-            self.execute(function() {
+            var callback = arguments[arguments.length - 1];
+
+            async.waterfall([
                 /**
                  * remove scrollbars
                  */
-                document.body.style.height = document.documentElement.scrollHeight + 'px';
-                document.body.style.overflow = 'hidden';
-
+                function(cb) {
+                    self.execute(function () {
+                        document.body.style.height = document.documentElement.scrollHeight + 'px';
+                        document.body.style.overflow = 'hidden';
+                    }, function (err) {
+                        // Only check for an error here, we don't need the actual result
+                        return err ? cb(err) : cb();
+                    });
+                },
                 /**
                  * scroll back to start scanning
                  */
-                window.scrollTo(0, 0);
-
+                function(cb) {
+                    self.execute(function () {
+                        window.scrollTo(0, 0);
+                    }, function (err) {
+                        // Only check for an error here, we don't need the actual result
+                        return err ? cb(err) : cb();
+                    });
+                },
                 /**
                  * get viewport width/height and total width/height
                  */
-                return {
-                    screenWidth: Math.max(document.documentElement.clientWidth, window.innerWidth || 0),
-                    screenHeight: Math.max(document.documentElement.clientHeight, window.innerHeight || 0),
-                    documentWidth: document.documentElement.scrollWidth,
-                    documentHeight: document.documentElement.scrollHeight,
-                    devicePixelRatio: window.devicePixelRatio
-                };
-            }, cb);
+                function(cb) {
+                    self.execute(function () {
+                        return {
+                            screenWidth: Math.max(document.documentElement.clientWidth, window.innerWidth || 0),
+                            screenHeight: Math.max(document.documentElement.clientHeight, window.innerHeight || 0),
+                            documentWidth: document.documentElement.scrollWidth,
+                            documentHeight: document.documentElement.scrollHeight,
+                            devicePixelRatio: window.devicePixelRatio
+                        };
+                    }, cb);
+                }
+            ], callback);
         },
 
         /*!


### PR DESCRIPTION
Hello!

As mentioned in #79 sometimes the first screenshot is taken too early and the scrollbars are still visible. In contrast to the solution proposed there I tried to solve it without a pause of _&lt;insert arbitrary number here&gt;_ ms. Splitting the script in three different execute blocks (that naturally take longer to execute than one) fixed the problem for me, but maybe a pause is still needed.

Best regards,
Ben
