### PR TITLE
Screenshot height for different viewport widths

### DIFF
--- a/lib/documentScreenshot.js
+++ b/lib/documentScreenshot.js
@@ -101,6 +101,8 @@ module.exports = function documentScreenshot(fileName) {
                 /**
                  * remove scrollbars
                  */
+                // reset height in case we're changing viewports
+                document.body.style.height = 'auto';
                 document.body.style.height = document.documentElement.scrollHeight + 'px';
                 document.body.style.overflow = 'hidden';
 


### PR DESCRIPTION
When changing viewport widths on the same url, the document height was always staying the same for all viewports so the screenshots for different viewports were not the correct height. This fix simply resets the doc height before re-calculating height. 
