### PR TITLE
Add option to tweak node-resemble-js image comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,9 @@ available:
 
 * **remove** `String[]`<br>
   removes all elements queried by all kinds of different [WebdriverIO selector strategies](http://webdriver.io/guide/usage/selectors.html) (via `display: none`)
+  
+* **ignore** `String`<br>
+  can be used to ignore color differences or differences caused by antialising artifacts in the screenshot comparison
 
 The following paragraphs will give you a more detailed insight how to use these options properly.
 
@@ -357,6 +360,24 @@ client
     });
 ```
 ![alt text](http://webdriver.io/images/webdrivercss/exclude2.png "Logo Title Text 1")
+
+### Tweak the image comparison
+
+If you experience problems with unstable comparison results you might want to try tweaking the algorithm.
+There are two options available: `colors` and `antialiasing`. `colors` might help you if you don't care about color differences on your page, while the `antialiasing` option can for example reduce unexpected differences on font or image edges:
+
+```js
+client
+    .url('http://tumblr.com/themes')
+    .webdrivercss('tumblrpage', {
+        name: 'startpage',
+        ignore: 'antialiasing',
+        screenWidth: [1200]
+    });
+```
+
+Note: This doesn't affect the taken screenshots, but only the comparison calculations.
+By setting this option you reduce the sensitivity of the comparison algorithm. Though it's unlikely this might cause layout changes to remain unnoticed.
 
 ### Keep an eye on mobile screen resolution
 

--- a/lib/compareImages.js
+++ b/lib/compareImages.js
@@ -23,8 +23,20 @@ module.exports = function() {
     /**
      * compare images
      */
-    resemble(this.baselinePath)
-        .compareTo(this.regressionPath)
-        .onComplete(done.bind(null,null));
+    var diff = resemble(this.baselinePath).compareTo(this.regressionPath);
 
+    /**
+     * map 'ignore' configuration to resemble options
+     */
+    var ignore = this.currentArgs.ignore || "";
+    if (ignore.indexOf("color") === 0) {
+        diff.ignoreColors();
+    } else if (ignore.indexOf("antialias") === 0) {
+        diff.ignoreAntialiasing();
+    }
+
+    /**
+     * execute the comparison
+     */
+    diff.onComplete(done.bind(null,null));
 };


### PR DESCRIPTION
Hey there!

In a few of our layout tests we had problems with random fails because of strange edges around some text characters and images. Using the `ignoreAntialiasing()` option of node-resemble-js fixed this. So this PR adds the option to specify resemble's ignoreColors/ignoreAntialiasing via the webdrivercss api.

Best regards,
Ben
