### PR TITLE
Adjust scrolling to better support sticky headers

### DIFF
--- a/lib/documentScreenshot.js
+++ b/lib/documentScreenshot.js
@@ -71,11 +71,11 @@ module.exports = function documentScreenshot(fileName) {
                 return;
             }
 
-            document.body.style.webkitTransform = 'translate(-' + w + 'px, -' + h + 'px)';
-            document.body.style.mozTransform = 'translate(-' + w + 'px, -' + h + 'px)';
-            document.body.style.msTransform = 'translate(-' + w + 'px, -' + h + 'px)';
-            document.body.style.oTransform = 'translate(-' + w + 'px, -' + h + 'px)';
-            document.body.style.transform = 'translate(-' + w + 'px, -' + h + 'px)';
+            document.documentElement.style.webkitTransform = 'translate(-' + w + 'px, -' + h + 'px)';
+            document.documentElement.style.mozTransform = 'translate(-' + w + 'px, -' + h + 'px)';
+            document.documentElement.style.msTransform = 'translate(-' + w + 'px, -' + h + 'px)';
+            document.documentElement.style.oTransform = 'translate(-' + w + 'px, -' + h + 'px)';
+            document.documentElement.style.transform = 'translate(-' + w + 'px, -' + h + 'px)';
         };
 
     async.waterfall([
@@ -102,9 +102,9 @@ module.exports = function documentScreenshot(fileName) {
                  * remove scrollbars
                  */
                 // reset height in case we're changing viewports
-                document.body.style.height = 'auto';
-                document.body.style.height = document.documentElement.scrollHeight + 'px';
-                document.body.style.overflow = 'hidden';
+                document.documentElement.style.height = 'auto';
+                document.documentElement.style.height = document.documentElement.scrollHeight + 'px';
+                document.documentElement.style.overflow = 'hidden';
 
                 /**
                  * scroll back to start scanning


### PR DESCRIPTION
I had some issues testing a site (http://theseasonatmaybourne.com) with a sticky header - I found that scrolling back to the top wasn't working and resulted in an offset on all subsequent crops. These changes seemed to produce more stable results.

All tests are passing, but I haven't had time to fully reproduce the issue add a specific case.
