### PR TITLE
Update getPageInfo.js

### DIFF
--- a/lib/getPageInfo.js
+++ b/lib/getPageInfo.js
@@ -177,6 +177,13 @@ module.exports = function(done) {
             })
             .then(function (excludeRect) {
                 done(null, excludeRect);
+            })
+            .catch(function(err){
+                if(err.type === 'NoSuchElement'){
+                    done(null, excludeRect);  
+                } else {
+                    done(err);
+                }
             });
         }
     ], function(err, excludeElements) {

--- a/test/spec/exclude.js
+++ b/test/spec/exclude.js
@@ -136,7 +136,15 @@ describe('WebdriverCSS should exclude parts of websites to ignore changing conte
                 });
             });
     });
-
+    it('should ignore missing elements on exclude',function(done){
+        this.browser
+            .url(testurl)
+            .webdrivercss('ignoreMissingElements', {
+              exclude: ["#not-really-here"],
+              name: '_'
+            })
+            .call(done);
+    });
     after(afterHook);
 
 });


### PR DESCRIPTION
Account for excluding elements that are not on page anymore. (Something like a toast message that you want to ignore but has already been removed from the page)
The test would timeout before, this allows NoSuchElement errors to continue on.  Other errors will pass the error on.
