### PR TITLE
Improve document height measurement

### DIFF
--- a/lib/documentScreenshot.js
+++ b/lib/documentScreenshot.js
@@ -98,13 +98,16 @@ module.exports = function documentScreenshot(fileName) {
         function() {
             var cb = arguments[arguments.length - 1];
             self.execute(function() {
+                var body = document.body,
+                    html = document.documentElement;
+
                 /**
                  * remove scrollbars
                  */
                 // reset height in case we're changing viewports
-                document.documentElement.style.height = 'auto';
-                document.documentElement.style.height = document.documentElement.scrollHeight + 'px';
-                document.documentElement.style.overflow = 'hidden';
+                body.style.height = 'auto';
+                body.style.height = html.scrollHeight + 'px';
+                body.style.overflow = 'hidden';
 
                 /**
                  * scroll back to start scanning
@@ -114,11 +117,13 @@ module.exports = function documentScreenshot(fileName) {
                 /**
                  * get viewport width/height and total width/height
                  */
+                var height = Math.max( body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight );
+
                 return {
-                    screenWidth: Math.max(document.documentElement.clientWidth, window.innerWidth || 0),
-                    screenHeight: Math.max(document.documentElement.clientHeight, window.innerHeight || 0),
-                    documentWidth: document.documentElement.scrollWidth,
-                    documentHeight: document.documentElement.scrollHeight,
+                    screenWidth: Math.max(html.clientWidth, window.innerWidth || 0),
+                    screenHeight: Math.max(html.clientHeight, window.innerHeight || 0),
+                    documentWidth: html.scrollWidth,
+                    documentHeight: height,
                     devicePixelRatio: window.devicePixelRatio
                 };
             }, cb);


### PR DESCRIPTION
On the website I was testing, due to the layout method we use (absolute positioning), the document height was always coming in as 0 in Chrome (would work fine in FF though). When Graphicsmagick attempted to use the screenshot, it would complain that one of the dimensions was zero. To fix this, I did a little bit of research (aka searched Stack Overflow) and found [a solution](http://stackoverflow.com/a/1147768/150552), which in my testing fixes the issue.

I've run the WebdriverCSS tests locally and it works great. I did my testing against the `beta-rc1` branch though, in order to test in WebdriverIO >3. I'm not sure if I should merge in to the master branch or `beta-rc1`.

FYI, [this is the page](https://projects.invisionapp.com/d/login) I'm having issues with. If you inspect the html/body tags in chrome, you'll notice the height of those elements is 0 (due to the `.overlay` content being absolutely positioned). 
