### PR TITLE
First pass at WebdriverCSS Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:5.7.1-onbuild
+MAINTAINER Owen Barton <owen.barton@civicactions.com>
+
+RUN apt-get update && \
+    apt-get install -y graphicsmagick && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN npm link && \
+    npm link webdrivercss
+
+CMD node 

--- a/lib/asyncCallback.js
+++ b/lib/asyncCallback.js
@@ -5,7 +5,8 @@
  */
 
 var workflow = require('./workflow.js'),
-    endSession = require('./endSession.js');
+    endSession = require('./endSession.js'),
+    fs = require('fs');
 
 module.exports = function(err) {
 
@@ -48,6 +49,9 @@ module.exports = function(err) {
      * finish command
      */
     return endSession.call(this, function(err) {
+        if(that.currentArgs && !that.currentArgs.totalScreen){
+            fs.unlinkSync(that.screenshot);
+        }
         that.self.takeScreenshot = undefined;
         that.cb(err, that.self.resultObject);
         that.self.resultObject = {};


### PR DESCRIPTION
This is a basic Dockerfile for WebdriverCSS. There is a build on https://hub.docker.com/r/grugnog/webdrivercss if you want to try it out (docs still WIP).

I am installing the webdrivercss module as a link, rather than from the NPM repo, so that it can be used more easily to test specific revisions/forks etc that don't have an official release.
