### PR TITLE
Assorted fixes for small bugs in master

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,1 +1,24 @@
-{ "presets": ["es2015"] }
+{
+    "plugins": [
+        "check-es2015-constants",
+        "transform-es2015-arrow-functions",
+        "transform-es2015-block-scoped-functions",
+        "transform-es2015-block-scoping",
+        "transform-es2015-classes",
+        "transform-es2015-computed-properties",
+        "transform-es2015-destructuring",
+        "transform-es2015-duplicate-keys",
+        "transform-es2015-for-of",
+        "transform-es2015-function-name",
+        "transform-es2015-literals",
+        "transform-es2015-modules-commonjs",
+        "transform-es2015-object-super",
+        "transform-es2015-parameters",
+        "transform-es2015-shorthand-properties",
+        "transform-es2015-spread",
+        "transform-es2015-sticky-regex",
+        "transform-es2015-template-literals",
+        "transform-es2015-typeof-symbol",
+        "transform-es2015-unicode-regex"
+    ]
+}

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -11,7 +11,7 @@ module.exports = function (grunt) {
                 files: [{
                     expand: true,
                     cwd: './lib',
-                    src: ['*.js'],
+                    src: ['**/*.js'],
                     dest: 'build',
                     ext: '.js'
                 }]
@@ -55,7 +55,6 @@ module.exports = function (grunt) {
     })
 
     require('load-grunt-tasks')(grunt)
-    grunt.loadTasks('build')
     grunt.registerTask('default', ['build'])
     grunt.registerTask('build', 'Build grunt-webdriver', function () {
         grunt.task.run([

--- a/lib/documentScreenshot.js
+++ b/lib/documentScreenshot.js
@@ -31,7 +31,7 @@ import getPageInfo from './scripts/getPageInfo'
 
 const CAPS_TAKING_FULLSIZE_SHOTS = ['firefox']
 
-export async function documentScreenshot (fileName) {
+export default async function documentScreenshot (fileName) {
     let ErrorHandler = this.instance.ErrorHandler
 
     /*!

--- a/lib/viewportScreenshot.js
+++ b/lib/viewportScreenshot.js
@@ -5,7 +5,7 @@
  */
 
 import gm from 'gm'
-import ErrorHandler from 'webdriverio/lib/utils/ErrorHandler'
+import { ErrorHandler } from 'webdriverio'
 
 import getScrollingPosition from './scripts/getScrollingPosition'
 import getScreenDimension from './scripts/getScreenDimension'

--- a/lib/webdrivercss.js
+++ b/lib/webdrivercss.js
@@ -13,7 +13,8 @@ const DEFAULT_PROPERTIES = {
     screenWidth: [],
     warning: [],
     resultObject: {},
-    updateBaseline: false
+    updateBaseline: false,
+    applitools: {}
 }
 
 /**

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -31,7 +31,11 @@ afterHook = function(done) {
      * close browser and clean up created directories
      */
     async.parallel([
-        function(done) { browser.end(done); },
+        function(done) {
+            browser.end()
+                .then(done.bind(null, null))
+                .catch(done);
+        },
         function(done) { fs.remove(failedComparisonsRootDefault,done); },
         function(done) { fs.remove(screenshotRootDefault,done); },
         function(done) { fs.remove(failedComparisonsRootCustom,done); },

--- a/test/spec/instantiation.js
+++ b/test/spec/instantiation.js
@@ -2,8 +2,8 @@
 
 describe('WebdriverCSS plugin as WebdriverIO enhancement', function() {
 
-    before(function(done) {
-        this.browser = WebdriverIO.remote(capabilities).init(done);
+    before(function() {
+        return this.browser = WebdriverIO.remote(capabilities).init();
     });
 
     it('should not exist as command in WebdriverIO instance without initialization', function() {
@@ -32,9 +32,9 @@ describe('WebdriverCSS plugin as WebdriverIO enhancement', function() {
     it('should contain some default values', function() {
         var plugin = WebdriverCSS.init(this.browser);
 
-        expect(plugin).to.have.property('screenshotRoot').to.equal('webdrivercss');
-        expect(plugin).to.have.property('failedComparisonsRoot').to.equal('webdrivercss/diff');
-        expect(plugin).to.have.property('misMatchTolerance').to.equal(0.05);
+        expect(plugin.options).to.have.property('screenshotRoot').to.equal('webdrivercss');
+        expect(plugin.options).to.have.property('failedComparisonsRoot').to.equal('webdrivercss/diff');
+        expect(plugin.options).to.have.property('misMatchTolerance').to.equal(0.05);
 
     });
 
@@ -45,9 +45,9 @@ describe('WebdriverCSS plugin as WebdriverIO enhancement', function() {
             misMatchTolerance: 50
         });
 
-        expect(plugin).to.have.property('screenshotRoot').to.equal('__screenshotRoot__');
-        expect(plugin).to.have.property('failedComparisonsRoot').to.equal('__failedComparisonsRoot__');
-        expect(plugin).to.have.property('misMatchTolerance').to.equal(50);
+        expect(plugin.options).to.have.property('screenshotRoot').to.equal('__screenshotRoot__');
+        expect(plugin.options).to.have.property('failedComparisonsRoot').to.equal('__failedComparisonsRoot__');
+        expect(plugin.options).to.have.property('misMatchTolerance').to.equal(50);
     });
 
     it('should have a created "screenshotRoot" folder after initialization', function(done) {


### PR DESCRIPTION
I was trying to see if I could get webdrivercss to work w/ the latest webdriverio. Then I realized a rewrite of webdrivercss is currently in progress, and the work was probably more than I could do in a couple of hours.

I managed to find and fix a couple bugs, though, while trying to get the instantiation.js test to pass. I figured they might be useful, so I created this PR.

Changes included:
- Don't use the es2015 preset since it requires the generator transform. Since Babel 6, the blacklist property is no longer supported in .babelrc, so I think the only alternative is to specify manually what transforms to use.
- In the gruntfile, the `loadTasks('build')` call would cause grunt to try and load tasks from the build directory. If the compiled files are in build, this causes grunt to fail.
- Made documentScreenshot.js export it's function as the default export (this is what webdriver.css was expecting).
- Don't require ErrorHandler directly from `lib/.../ErrorHandler` since this will try and load webdriverio's ES6 JS instead of the compiled JS.
- Make sure there is an `applitools` key in `DEFAULT_PROPERTIES` since many files expect it to be there (eg, workflow.js).
- In `afterHook` in bootstrap.js, don't pass a callback to browser.end() since it returns a promise now.
- Get parts of the instantiation spec to pass. I couldn't get all of them to pass since it calls WebDriverCSS.init() multiple times (resulting in 'command already defined' errors). I believe the best way to fix this is to isolate the tests in that spec more, but I didn't want to make this PR any bigger.

If the PR requires some changes, let me know.
