### PR TITLE
Add new option to webdriverCSS

### DIFF
--- a/lib/saveImageDiff.js
+++ b/lib/saveImageDiff.js
@@ -4,10 +4,10 @@ var fs = require('fs'),
     async = require('async'),
     logWarning = require('./logWarning.js');
 
-module.exports = function(imageDiff, done) {
+module.exports = function(imageDiff,done) {
 
     var that = this,
-        misMatchTolerance = parseFloat(imageDiff.misMatchPercentage, 10);
+        misMatchTolerance = parseFloat(imageDiff.misMatchPercentage,10);
 
     /**
      * Remove usual screenshot if it's not needed
@@ -20,7 +20,7 @@ module.exports = function(imageDiff, done) {
         });
     }
 
-    if (typeof imageDiff === 'function') {
+    if(typeof imageDiff === 'function') {
         this.self.resultObject[this.currentArgs.name].push({
             baselinePath: this.baselinePath,
             message: 'first image of module "' + this.currentArgs.name + '" from page "' + this.pagename + '" successfully taken',
@@ -38,10 +38,10 @@ module.exports = function(imageDiff, done) {
      * if set misMatchTolerance is smaller then compared misMatchTolerance
      * make image diff
      */
-    if (this.misMatchTolerance < misMatchTolerance) {
+    if(this.misMatchTolerance < misMatchTolerance) {
 
         /*istanbul ignore next*/
-        if (!imageDiff.isSameDimensions) {
+        if(!imageDiff.isSameDimensions) {
             logWarning.call(this.instance, 'DimensionWarning');
         }
 
@@ -63,23 +63,23 @@ module.exports = function(imageDiff, done) {
 
     } else {
 
-        /**
-         * otherwise delete diff
-         */
+    /**
+     * otherwise delete diff
+     */
 
         async.waterfall([
             /**
              * check if diff shot exists
              */
             function(done) {
-                fs.exists(that.diffPath, done.bind(null, null));
+                fs.exists(that.diffPath,done.bind(null,null));
             },
             /**
              * remove diff if yes
              */
-            function(exists, done) {
-                if (exists) {
-                    fs.unlink(that.diffPath, done);
+            function(exists,done) {
+                if(exists) {
+                    fs.unlink(that.diffPath,done);
                 } else {
                     done();
                 }

--- a/lib/saveImageDiff.js
+++ b/lib/saveImageDiff.js
@@ -4,12 +4,23 @@ var fs = require('fs'),
     async = require('async'),
     logWarning = require('./logWarning.js');
 
-module.exports = function(imageDiff,done) {
+module.exports = function(imageDiff, done) {
 
     var that = this,
-        misMatchTolerance = parseFloat(imageDiff.misMatchPercentage,10);
+        misMatchTolerance = parseFloat(imageDiff.misMatchPercentage, 10);
 
-    if(typeof imageDiff === 'function') {
+    /**
+     * Remove usual screenshot if it's not needed
+     */
+    if (that.self.removeScreenshot) {
+        fs.unlink(this.screenshot, (err) => {
+            if (err) {
+                throw err;
+            }
+        });
+    }
+
+    if (typeof imageDiff === 'function') {
         this.self.resultObject[this.currentArgs.name].push({
             baselinePath: this.baselinePath,
             message: 'first image of module "' + this.currentArgs.name + '" from page "' + this.pagename + '" successfully taken',
@@ -27,10 +38,10 @@ module.exports = function(imageDiff,done) {
      * if set misMatchTolerance is smaller then compared misMatchTolerance
      * make image diff
      */
-    if(this.misMatchTolerance < misMatchTolerance) {
+    if (this.misMatchTolerance < misMatchTolerance) {
 
         /*istanbul ignore next*/
-        if(!imageDiff.isSameDimensions) {
+        if (!imageDiff.isSameDimensions) {
             logWarning.call(this.instance, 'DimensionWarning');
         }
 
@@ -52,23 +63,23 @@ module.exports = function(imageDiff,done) {
 
     } else {
 
-    /**
-     * otherwise delete diff
-     */
+        /**
+         * otherwise delete diff
+         */
 
         async.waterfall([
             /**
              * check if diff shot exists
              */
             function(done) {
-                fs.exists(that.diffPath,done.bind(null,null));
+                fs.exists(that.diffPath, done.bind(null, null));
             },
             /**
              * remove diff if yes
              */
-            function(exists,done) {
-                if(exists) {
-                    fs.unlink(that.diffPath,done);
+            function(exists, done) {
+                if (exists) {
+                    fs.unlink(that.diffPath, done);
                 } else {
                     done();
                 }

--- a/lib/setScreenWidth.js
+++ b/lib/setScreenWidth.js
@@ -18,7 +18,7 @@ module.exports = function(done) {
          * after all shots were taken (only if a screenWidth is set)
          */
         function(cb) {
-            if(!that.self.defaultScreenDimension && that.screenWidth && that.screenWidth.length) {
+            if (!that.self.defaultScreenDimension && that.screenWidth && that.screenWidth.length) {
                 that.instance.windowHandleSize()
                     .then(function(res) {
                         that.self.defaultScreenDimension = res.value;
@@ -30,7 +30,7 @@ module.exports = function(done) {
         },
         function(cb) {
 
-            if(!that.screenWidth || that.screenWidth.length === 0) {
+            if (!that.screenWidth || that.screenWidth.length === 0) {
 
                 /**
                  * if no screenWidth option was set just continue
@@ -43,7 +43,7 @@ module.exports = function(done) {
             that.newScreenSize.height = parseInt(that.self.defaultScreenDimension.height, 10);
 
             that.self.takeScreenshot = false;
-            if(!takenScreenSizes[that.pagename] || takenScreenSizes[that.pagename].indexOf(that.newScreenSize.width) < 0) {
+            if (!takenScreenSizes[that.pagename] || takenScreenSizes[that.pagename].indexOf(that.newScreenSize.width) < 0) {
                 /**
                  * set flag to retake screenshot
                  */
@@ -52,7 +52,7 @@ module.exports = function(done) {
                 /**
                  * cache already taken screenshot / screenWidth combinations
                  */
-                if(!takenScreenSizes[that.pagename]) {
+                if (!takenScreenSizes[that.pagename]) {
                     takenScreenSizes[that.pagename] = [that.newScreenSize.width];
                 } else {
                     takenScreenSizes[that.pagename].push(that.newScreenSize.width);
@@ -68,15 +68,18 @@ module.exports = function(done) {
                  * if shot will be taken in a specific screenWidth, rename file and append screen width
                  * value in filename
                  */
-                that.baselinePath   = that.baselinePath.replace(/\.(baseline|regression|diff)\.png/,'.' + that.newScreenSize.width + 'px.$1.png');
-                that.regressionPath = that.regressionPath.replace(/\.(baseline|regression|diff)\.png/,'.' + that.newScreenSize.width + 'px.$1.png');
-                that.diffPath       = that.diffPath.replace(/\.(baseline|regression|diff)\.png/,  '.' + that.newScreenSize.width + 'px.$1.png');
-                that.screenshot     = that.screenshot.replace(/\.png/, '.' + that.newScreenSize.width + 'px.png');
-                that.filename       = that.baselinePath;
+                that.baselinePath = that.baselinePath.replace(/\.(baseline|regression|diff)\.png/, '.' + that.newScreenSize.width + 'px.$1.png');
+                that.regressionPath = that.regressionPath.replace(/\.(baseline|regression|diff)\.png/, '.' + that.newScreenSize.width + 'px.$1.png');
+                that.diffPath = that.diffPath.replace(/\.(baseline|regression|diff)\.png/, '.' + that.newScreenSize.width + 'px.$1.png');
+                that.screenshot = that.screenshot.replace(/\.png/, '.' + that.newScreenSize.width + 'px.png');
+                that.filename = that.baselinePath;
 
-                that.instance.setViewportSize({width: that.newScreenSize.width, height: that.newScreenSize.height})
-                             .pause(100)
-                             .call(cb);
+                that.instance.setViewportSize({
+                        width: that.newScreenSize.width,
+                        height: that.newScreenSize.height
+                    })
+                    .pause(that.viewportChangePause)
+                    .call(cb);
 
             });
         }

--- a/lib/webdrivercss.js
+++ b/lib/webdrivercss.js
@@ -17,7 +17,7 @@ var fs = require('fs-extra'),
 var WebdriverCSS = function(webdriverInstance, options) {
     options = options || {};
 
-    if (!webdriverInstance) {
+    if(!webdriverInstance) {
         throw new Error('A WebdriverIO instance is needed to initialise WebdriverCSS');
     }
 
@@ -56,10 +56,10 @@ var WebdriverCSS = function(webdriverInstance, options) {
     this.saveImages = options.saveImages || !this.usesApplitools;
 
     /**
-     * create directory if it doesn't already exist
-     */
+    * create directory if it doesn't already exist
+    */
     var createDirectory = function(path) {
-        if (!fs.existsSync(path)) {
+        if(!fs.existsSync(path)) {
             fs.mkdirsSync(path, '0755', true);
         }
     };

--- a/lib/webdrivercss.js
+++ b/lib/webdrivercss.js
@@ -17,7 +17,7 @@ var fs = require('fs-extra'),
 var WebdriverCSS = function(webdriverInstance, options) {
     options = options || {};
 
-    if(!webdriverInstance) {
+    if (!webdriverInstance) {
         throw new Error('A WebdriverIO instance is needed to initialise WebdriverCSS');
     }
 
@@ -27,6 +27,7 @@ var WebdriverCSS = function(webdriverInstance, options) {
     this.screenshotRoot = options.screenshotRoot || 'webdrivercss';
     this.failedComparisonsRoot = options.failedComparisonsRoot || (this.screenshotRoot + '/diff');
     this.misMatchTolerance = options.misMatchTolerance || 0.05;
+    this.viewportChangePause = options.viewportChangePause || 100;
     this.screenWidth = options.screenWidth || [];
     this.removeScreenshot = options.removeScreenshot || false;
     this.warning = [];
@@ -56,10 +57,10 @@ var WebdriverCSS = function(webdriverInstance, options) {
     this.saveImages = options.saveImages || !this.usesApplitools;
 
     /**
-    * create directory if it doesn't already exist
-    */
+     * create directory if it doesn't already exist
+     */
     var createDirectory = function(path) {
-        if(!fs.existsSync(path)) {
+        if (!fs.existsSync(path)) {
             fs.mkdirsSync(path, '0755', true);
         }
     };

--- a/lib/webdrivercss.js
+++ b/lib/webdrivercss.js
@@ -17,7 +17,7 @@ var fs = require('fs-extra'),
 var WebdriverCSS = function(webdriverInstance, options) {
     options = options || {};
 
-    if(!webdriverInstance) {
+    if (!webdriverInstance) {
         throw new Error('A WebdriverIO instance is needed to initialise WebdriverCSS');
     }
 
@@ -28,6 +28,7 @@ var WebdriverCSS = function(webdriverInstance, options) {
     this.failedComparisonsRoot = options.failedComparisonsRoot || (this.screenshotRoot + '/diff');
     this.misMatchTolerance = options.misMatchTolerance || 0.05;
     this.screenWidth = options.screenWidth || [];
+    this.removeScreenshot = options.removeScreenshot || false;
     this.warning = [];
     this.resultObject = {};
     this.instance = webdriverInstance;
@@ -50,15 +51,15 @@ var WebdriverCSS = function(webdriverInstance, options) {
     };
     this.reqTimeout = 5 * 60 * 1000;
     this.user = options.user;
-    this.api  = options.api;
+    this.api = options.api;
     this.usesApplitools = typeof this.applitools.apiKey === 'string' && !this.api;
     this.saveImages = options.saveImages || !this.usesApplitools;
 
     /**
-    * create directory if it doesn't already exist
-    */
+     * create directory if it doesn't already exist
+     */
     var createDirectory = function(path) {
-        if(!fs.existsSync(path)) {
+        if (!fs.existsSync(path)) {
             fs.mkdirsSync(path, '0755', true);
         }
     };

--- a/lib/workflow.js
+++ b/lib/workflow.js
@@ -57,83 +57,84 @@ function workflow(pagename, args) {
         /**
          * default attributes
          */
-        misMatchTolerance:      this.misMatchTolerance,
-        screenshotRoot:         this.screenshotRoot,
-        failedComparisonsRoot:  this.failedComparisonsRoot,
+        misMatchTolerance: this.misMatchTolerance,
+        screenshotRoot: this.screenshotRoot,
+        failedComparisonsRoot: this.failedComparisonsRoot,
 
-        instance:       this.instance,
-        pagename:       pagename,
-        applitools:     {
+        instance: this.instance,
+        pagename: pagename,
+        applitools: {
             apiKey: this.applitools.apiKey,
             appName: pagename,
             saveNewTests: this.applitools.saveNewTests,
             saveFailedTests: this.applitools.saveFailedTests,
             batchId: this.applitools.batchId // Group all sessions for this instance together.
         },
-        currentArgs:    currentArgs,
-        queuedShots:    queuedShots,
-        baselinePath:   this.screenshotRoot + '/' + pagename + '.' + currentArgs.name + '.baseline.png',
+        currentArgs: currentArgs,
+        queuedShots: queuedShots,
+        baselinePath: this.screenshotRoot + '/' + pagename + '.' + currentArgs.name + '.baseline.png',
         regressionPath: this.screenshotRoot + '/' + pagename + '.' + currentArgs.name + '.regression.png',
-        diffPath:       this.failedComparisonsRoot + '/' + pagename + '.' + currentArgs.name + '.diff.png',
-        screenshot:     this.screenshotRoot + '/' + pagename + '.png',
-        isComparable:   false,
-        warnings:       [],
-        newScreenSize:  0,
-        pageInfo:       null,
+        diffPath: this.failedComparisonsRoot + '/' + pagename + '.' + currentArgs.name + '.diff.png',
+        screenshot: this.screenshotRoot + '/' + pagename + '.png',
+        isComparable: false,
+        warnings: [],
+        newScreenSize: 0,
+        pageInfo: null,
         updateBaseline: (typeof currentArgs.updateBaseline === 'boolean') ? currentArgs.updateBaseline : this.updateBaseline,
-        screenWidth:    currentArgs.screenWidth || [].concat(this.screenWidth), // create a copy of the origin default screenWidth
-        cb:             cb
+        screenWidth: currentArgs.screenWidth || [].concat(this.screenWidth), // create a copy of the origin default screenWidth
+        viewportChangePause: this.viewportChangePause || 100,
+        cb: cb
     };
 
     /**
      * initiate result object
      */
-    if(!this.resultObject[currentArgs.name]) {
+    if (!this.resultObject[currentArgs.name]) {
         this.resultObject[currentArgs.name] = [];
     }
 
     async.waterfall([
 
-        /**
-         * initialize session
-         */
-        require('./startSession.js').bind(context),
+            /**
+             * initialize session
+             */
+            require('./startSession.js').bind(context),
 
-        /**
-         * if multiple screen width are given resize browser dimension
-         */
-        require('./setScreenWidth.js').bind(context),
+            /**
+             * if multiple screen width are given resize browser dimension
+             */
+            require('./setScreenWidth.js').bind(context),
 
-        /**
-         * make screenshot via [GET] /session/:sessionId/screenshot
-         */
-        require('./makeScreenshot.js').bind(context),
+            /**
+             * make screenshot via [GET] /session/:sessionId/screenshot
+             */
+            require('./makeScreenshot.js').bind(context),
 
-        /**
-         * check if files with id already exists
-         */
-        require('./renameFiles.js').bind(context),
+            /**
+             * check if files with id already exists
+             */
+            require('./renameFiles.js').bind(context),
 
-        /**
-         * get page informations
-         */
-        require('./getPageInfo.js').bind(context),
+            /**
+             * get page informations
+             */
+            require('./getPageInfo.js').bind(context),
 
-        /**
-         * crop image according to user arguments and its position on screen and save it
-         */
-        require('./cropImage.js').bind(context),
+            /**
+             * crop image according to user arguments and its position on screen and save it
+             */
+            require('./cropImage.js').bind(context),
 
-        /**
-         * compare images
-         */
-        require('./compareImages.js').bind(context),
+            /**
+             * compare images
+             */
+            require('./compareImages.js').bind(context),
 
-        /**
-         * save image diff
-         */
-        require('./saveImageDiff.js').bind(context)
-    ],
+            /**
+             * save image diff
+             */
+            require('./saveImageDiff.js').bind(context)
+        ],
         /**
          * run workflow again or execute callback function
          */


### PR DESCRIPTION
Hi!

Now, after layout verification WebdriverCSS creates a screenshot of the page and reference screenshot (baseline). A simple screenshot of the page is not necessary and is preventing to upload screens to the remote server (too large tar archive will be with this screenshots). So I added the option to remove the usual screenshots
