### PR TITLE
Image comparison: disable largeImageThreshold

### DIFF
--- a/lib/compareImages.js
+++ b/lib/compareImages.js
@@ -22,7 +22,7 @@ module.exports = function() {
 
     // This feature makes the output nearly worthless and impossible to read.
     // Turn it off.
-    resemble.outputOptions({largeImageThreshold:0})
+    resemble.outputSettings({largeImageThreshold:0})
 
     /**
      * compare images

--- a/lib/compareImages.js
+++ b/lib/compareImages.js
@@ -21,8 +21,8 @@ module.exports = function() {
     }
 
     // This feature makes the output nearly worthless and impossible to read.
-    // Set it high enought that we never hit it.
-    resemble.outputOptions({largeImageThreshold:1000000000})
+    // Turn it off.
+    resemble.outputOptions({largeImageThreshold:0})
 
     /**
      * compare images

--- a/lib/compareImages.js
+++ b/lib/compareImages.js
@@ -20,6 +20,10 @@ module.exports = function() {
         return done();
     }
 
+    // This feature makes the output nearly worthless and impossible to read.
+    // Set it high enought that we never hit it.
+    resemble.outputOptions({largeImageThreshold:1000000000})
+
     /**
      * compare images
      */

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "fs-extra": "^0.18.2",
     "glob": "^5.0.5",
     "gm": "^1.17.0",
-    "node-resemble-js": "0.0.4",
+    "node-resemble-js": "0.2.0",
     "request": "^2.55.0",
     "rimraf": "^2.3.2",
     "tar": "^2.1.0",


### PR DESCRIPTION
This "feature" makes the output nearly unusable and ironically
significantly larger (in filesize) at the benefit of saving ~20% of runtime

Set the threshold to 0 so it's turned off.

Before:
![image](https://cloud.githubusercontent.com/assets/26855/20763717/1a202850-b6e0-11e6-96be-08517ac4faba.png)

After:
![image](https://cloud.githubusercontent.com/assets/26855/20764858/eb04cc6a-b6e4-11e6-81b0-15967dfac2e3.png)
